### PR TITLE
Node.jsとnode-sassのバージョンの依存関係を解消

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "@rails/activestorage": "^6.0.0",
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "4.3.0",
-    "turbolinks": "^5.2.0"
+    "turbolinks": "^5.2.0",
+    "node-sass": "^4.14.1"
   },
   "version": "0.1.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4576,7 +4576,7 @@ node-releases@^2.0.14:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.14.tgz#2ffb053bceb8b2be8495ece1ab6ce600c4461b0b"
   integrity sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==
 
-node-sass@^4.13.0:
+node-sass@^4.13.0, node-sass@^4.14.1:
   version "4.14.1"
   resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.14.1.tgz#99c87ec2efb7047ed638fb4c9db7f3a42e2217b5"
   integrity sha512-sjCuOlvGyCJS40R8BscF5vhVlQjNN069NtQ1gSxyK1u9iqvn6tf7O1R4GNowVZfiZUCRt5MmMs1xd+4V/7Yr0g==


### PR DESCRIPTION
- package.jsonに "node-sass": "^4.14.1" を追記
- ターミナルで「yarn install」を実行
- ターミナルで「RAILS_ENV=production bundle exec rake assets:precompile」を実行し、エラーが発生しないことをローカル環境で確認した